### PR TITLE
Feat/aop

### DIFF
--- a/src/main/java/io/dcns/wantitauction/domain/auctionItem/service/MyAuctionItemService.java
+++ b/src/main/java/io/dcns/wantitauction/domain/auctionItem/service/MyAuctionItemService.java
@@ -8,6 +8,7 @@ import io.dcns.wantitauction.domain.auctionItem.entity.AuctionItem;
 import io.dcns.wantitauction.domain.auctionItem.repository.AuctionItemQueryRepository;
 import io.dcns.wantitauction.domain.auctionItem.repository.AuctionItemRepository;
 import io.dcns.wantitauction.domain.user.entity.User;
+import io.dcns.wantitauction.global.aop.ForbiddenKeyword;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class MyAuctionItemService {
     private final AuctionItemQueryRepository auctionItemQueryRepository;
 
     @Transactional
+    @ForbiddenKeyword
     public void createAuctionItem(CreateProductRequestDto request, User user) {
         auctionItemRepository.save(new AuctionItem(request, user));
     }

--- a/src/main/java/io/dcns/wantitauction/domain/point/service/PointService.java
+++ b/src/main/java/io/dcns/wantitauction/domain/point/service/PointService.java
@@ -1,6 +1,5 @@
 package io.dcns.wantitauction.domain.point.service;
 
-import io.dcns.wantitauction.domain.event.WinningBidEvent;
 import io.dcns.wantitauction.domain.point.dto.PointChangedResponseDto;
 import io.dcns.wantitauction.domain.point.dto.PointRequestDto;
 import io.dcns.wantitauction.domain.point.dto.PointResponseDto;
@@ -10,6 +9,7 @@ import io.dcns.wantitauction.domain.pointLog.entity.PointLog;
 import io.dcns.wantitauction.domain.pointLog.entity.PointLogStatus;
 import io.dcns.wantitauction.domain.pointLog.repository.PointLogRepository;
 import io.dcns.wantitauction.domain.user.entity.User;
+import io.dcns.wantitauction.global.event.WinningBidEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;

--- a/src/main/java/io/dcns/wantitauction/global/aop/ForbiddenKeyword.java
+++ b/src/main/java/io/dcns/wantitauction/global/aop/ForbiddenKeyword.java
@@ -1,0 +1,12 @@
+package io.dcns.wantitauction.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface ForbiddenKeyword {
+
+}

--- a/src/main/java/io/dcns/wantitauction/global/aop/ForbiddenKeywordAOP.java
+++ b/src/main/java/io/dcns/wantitauction/global/aop/ForbiddenKeywordAOP.java
@@ -1,0 +1,38 @@
+package io.dcns.wantitauction.global.aop;
+
+import io.dcns.wantitauction.domain.auctionItem.dto.CreateProductRequestDto;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class ForbiddenKeywordAOP {
+
+    @Pointcut("@annotation(io.dcns.wantitauction.global.aop.ForbiddenKeyword)")
+    private void forbiddenKeywordPoint() {
+    }
+
+    @Before("forbiddenKeywordPoint()")
+    public void forbiddenKeywordAOP(JoinPoint joinPoint) {
+        System.out.println("금지 품목 키워드 검색");
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof CreateProductRequestDto) {
+                String itemDescription = ((CreateProductRequestDto) arg).getItemDescription()
+                    .toLowerCase(); // 영문은 소문자로 변환하여 검열
+                ForbiddenKeywords[] forbiddenKeywords = ForbiddenKeywords.values();
+                for (ForbiddenKeywords forbiddenKeyword : forbiddenKeywords) {
+                    if (itemDescription.contains(forbiddenKeyword.getKorean())
+                        || itemDescription.contains(forbiddenKeyword.getEnglish())
+                    ) {
+                        throw new IllegalArgumentException("금지 품목 키워드가 포함되어 있습니다.");
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/dcns/wantitauction/global/aop/ForbiddenKeywords.java
+++ b/src/main/java/io/dcns/wantitauction/global/aop/ForbiddenKeywords.java
@@ -1,0 +1,23 @@
+package io.dcns.wantitauction.global.aop;
+
+public enum ForbiddenKeywords {
+    ALCOHOL("주류", "alcohol"),
+    TOBACCO("담배", "tobacco"),
+    DRUG("마약", "drug"),
+    GUN("총", "gun");
+    private final String korean;
+    private final String english;
+
+    ForbiddenKeywords(String korean, String english) {
+        this.korean = korean;
+        this.english = english;
+    }
+
+    public String getKorean() {
+        return korean;
+    }
+
+    public String getEnglish() {
+        return english;
+    }
+}

--- a/src/main/java/io/dcns/wantitauction/global/event/WinningBidEvent.java
+++ b/src/main/java/io/dcns/wantitauction/global/event/WinningBidEvent.java
@@ -1,4 +1,4 @@
-package io.dcns.wantitauction.domain.event;
+package io.dcns.wantitauction.global.event;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/io/dcns/wantitauction/global/scheduler/Scheduler.java
+++ b/src/main/java/io/dcns/wantitauction/global/scheduler/Scheduler.java
@@ -1,10 +1,10 @@
-package io.dcns.wantitauction.domain.scheduler;
+package io.dcns.wantitauction.global.scheduler;
 
 import io.dcns.wantitauction.domain.auctionItem.entity.AuctionItem;
 import io.dcns.wantitauction.domain.auctionItem.repository.AuctionItemQueryRepository;
 import io.dcns.wantitauction.domain.bid.entity.Bid;
 import io.dcns.wantitauction.domain.bid.repository.BidRepository;
-import io.dcns.wantitauction.domain.event.WinningBidEvent;
+import io.dcns.wantitauction.global.event.WinningBidEvent;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
## 변경사항

---
a642d21895f66f6fd6b4d82a060e90332cb4dd38 : 금지품목 키워드 검열 AOP 구현

CreateRequestDto의 itemDescription을 기준으로 검열이 동작합니다.
영어인 경우는 소문자로 변환하여 비교합니다.

### 변경의 종류 (여러 가지 선택 가능)

- [x] 새로운 기능
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 테스트 추가
- [ ] 기타(설명 추가)

## 체크리스트

- [x] ERD설계와 API설계를 잘 적용하여 개발하였는가?
- [ ] 테스트는 모든 경우를 고려하였는가?
- [x] 코딩 컨벤션을 준수하였는가?
- [x] 예외 처리가 잘 되어 있는가?
